### PR TITLE
Lock on target with control input

### DIFF
--- a/cameras/follow_cam/follow_cam_3d.gd
+++ b/cameras/follow_cam/follow_cam_3d.gd
@@ -71,6 +71,7 @@ func mouse_control(_event):
 
 		var clamped_rotation = clamp(new_rotation, -.8, 0.8) #rotation clamp
 		rotation.x = clamped_rotation
+		_lookat_target()
 		return
 
 func joystick_control(): # For controlling freecam rotation on gamepad
@@ -83,6 +84,7 @@ func joystick_control(): # For controlling freecam rotation on gamepad
 	
 	var clamped_rotation = clamp(temporary_rotation, -.8, .8)
 	rotation.x = clamped_rotation
+	_lookat_target()
 
 func _detect_camera_change():
 	if camera_3d != get_viewport().get_camera_3d() \


### PR DESCRIPTION
Why we want this: If mouse/controller input is accepted while we are locked to a target we get jittery motion as one frame will have the motion and the next its snapped back to the target. This ensures we just stay snapped to the target. I'm assuming this is the intended behavior.

Really we could ignore input if we're locked, but i found this method to be more reliable AND if we want some limited movement while staying locked this easily allows that implemented. ( I have that version - happy to share if that's desired but felt like keeping the template simple was best.)

Really love this project/template and I'm planning to go through and submit any PR's for issues I think are bugs or incomplete features. Thanks so much for creating this and making it open source <3